### PR TITLE
Input no longer emits 'input' more than necessary

### DIFF
--- a/src/components/Form/Controls/Input.tsx
+++ b/src/components/Form/Controls/Input.tsx
@@ -85,7 +85,7 @@ export class Input extends TsxComponent<Props> {
 
   @Inject({ default: null }) public itemIdentificationProvider!: ItemIdentification | null;
 
-  get inputId(): string | null {
+  private get inputId(): string | null {
     const id = this.id;
     if (id != null) { return id; }
     const provider = this.itemIdentificationProvider;
@@ -100,7 +100,7 @@ export class Input extends TsxComponent<Props> {
       <input
         id={this.inputId}
         value={this.currentValue}
-        on-input={event => this.updateInput(event)}
+        on-input={this.updateInput}
         readonly={this.readonly}
         disabled={this.disabled}
         type={this.type}
@@ -114,24 +114,20 @@ export class Input extends TsxComponent<Props> {
   @Watch('value')
   public handleNewValue(newValue) {
     this.currentValue = newValue;
-    this.$emit('update:value', this.currentValue);
-    this.$emit('input', this.currentValue);
   }
 
-  @Watch('currentValue')
-  public handleNewCurrentValue(newValue) {
-    this.currentValue = newValue;
-    this.$emit('update:value', this.currentValue);
-    this.$emit('input', this.currentValue);
-
-  }
   private updateInput(event) {
-    this.currentValue = event.target.value;
-    this.$emit('input', event.target.value);
+    const { target } = event;
+    let value: null | string = null;
+    if(target != null) {
+      value = target.value;
+    }
+    this.currentValue = value;
+    this.$emit('input', this.currentValue);
     this.$emit('update:value', this.currentValue);
   }
 
-  public currentValue = this.value === undefined || this.value === null ? '' : this.value;
+  public currentValue: string | number | null = this.value === undefined || this.value === null ? '' : this.value;
 
   private get classes() {
     return {


### PR DESCRIPTION
This PR fixes #33. Up until now `FdInput` emitted `input` more frequently than necessary.

@deepshikha02 I made sure that `FdSearchInput` still works. However, 4 eyes are better than 2. My upcoming 1.3.3 branch will introduce a few unit tests and until then we may resort to some kind of manual testing. :D