### PR TITLE
support ... when more than 3 pages and add more test

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -45,7 +45,7 @@ export class Pagination extends TsxComponent<Props> {
 
   private selectedPage: number = this.initialPage ? this.initialPage : 1;
   // when selectedPage = 27, render like [1,...26,27,28,...100]
-  private neighbourToShow: number = 1;
+  private numberOfNeighbour: number = 1;
 
   private createPaginationLinks(numberOfPages: number) {
     // create an array with number of pages and fill it with links
@@ -55,7 +55,7 @@ export class Pagination extends TsxComponent<Props> {
     aPages = Array(numberOfPages)
     .fill(0)
     .reduce((links, link, index) => {
-      if (index === 0 || index === this.numberOfPages - 1 || (index >= this.selectedPage - this.neighbourToShow -1 && index <= this.selectedPage + this.neighbourToShow -1)) {
+      if (index === 0 || index === this.numberOfPages - 1 || (index >= this.selectedPage - this.numberOfNeighbour -1 && index <= this.selectedPage + this.numberOfNeighbour -1)) {
         links.push(
           <a
             key={index}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -44,22 +44,45 @@ export class Pagination extends TsxComponent<Props> {
   );
 
   private selectedPage: number = this.initialPage ? this.initialPage : 1;
+  // when selectedPage = 27, render like [1,...26,27,28,...100]
+  private neighbourToShow: number = 1;
 
   private createPaginationLinks(numberOfPages: number) {
     // create an array with number of pages and fill it with links
-    const aPages = Array(numberOfPages)
-      .fill(0)
-      .map((link, index) => (
-        <a
-          key={index}
-          href='#'
-          class='fd-pagination__link'
-          aria-selected={this.selectedPage === index + 1}
-          onClick={(event: Event) => this.pageClicked(event)}
-        >
-          {index + 1}
-        </a>
-      ));
+    let aPages: any[] = [];
+    // flag to mark if ... need to be generated
+    let notSuppressed = true;
+    aPages = Array(numberOfPages)
+    .fill(0)
+    .reduce((links, link, index) => {
+      if (index === 0 || index === this.numberOfPages - 1 || (index >= this.selectedPage - this.neighbourToShow -1 && index <= this.selectedPage + this.neighbourToShow -1)) {
+        links.push(
+          <a
+            key={index}
+            href='#'
+            class='fd-pagination__link'
+            aria-selected={this.selectedPage === index + 1}
+            onClick={(event: Event) => this.pageClicked(event)}
+          >
+            {index + 1}
+          </a>,
+        );
+        notSuppressed = true;
+      } else if (notSuppressed === true) {
+        links.push(
+          // tslint:disable-next-line:jsx-self-close
+          <span
+            class='fd-pagination__link fd-pagination__link--more'
+            aria-hidden='true'
+            aria-label='...'
+            role='presentation'
+          >
+          </span>,
+        );
+        notSuppressed = false;
+      }
+      return links;
+    }, []);
     return aPages;
   }
 

--- a/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -14,11 +14,13 @@ describe('Pagination', () => {
   const vm = pagination.vm;
   const links = pagination.findAll('a');
   const leftArrow = links.at(0);
-  const rightArrow = links.at(12);
+  const rightArrow = links.at(4);
+  const pageOne = links.at(1);
+  const lastPage = links.at(3);
 
-  it('have total 13 hyperlinks rendered', () => {
-    // 11 pages + 2 arrows
-    assert.lengthOf(links, 13);
+  it('have total 5 hyperlinks rendered', () => {
+    // 4 pages [1,2,11] + 2 arrows
+    assert.lengthOf(links, 5);
   });
 
   it('the initial state', () => {
@@ -37,7 +39,6 @@ describe('Pagination', () => {
 
   it('toggle between page 1 and 2 using arrows', () => {
     // pageOne is at index 1 because there is left arrow at index 0
-    const pageOne = links.at(1);
     const pageTwo = links.at(2);
     expect(pageOne.attributes('aria-selected')).to.equal('true');
     assert.isUndefined(pageTwo.attributes('aria-selected'));
@@ -50,11 +51,20 @@ describe('Pagination', () => {
   });
 
   it('move to last page by clicking on it and right arrow is disabled', () => {
-    // pageOne is at index 1 because there is left arrow at index 0
-    const lastPage = links.at(11);
     assert.isUndefined(lastPage.attributes('aria-selected'));
     lastPage.trigger('click');
     expect(lastPage.attributes('aria-selected')).to.equal('true');
     expect(rightArrow.attributes('aria-disabled')).to.equal('true');
   });
+
+  it('click right arrow twice and ... appears at the correct place', () => {
+    // reset to pageOne
+    pageOne.trigger('click');
+    rightArrow.trigger('click');
+    rightArrow.trigger('click');
+    const newLinks = pagination.findAll('a');
+    // [1,2,3,4,...,11] + 2 arrows
+    assert.lengthOf(newLinks, 7);
+  });
+
 });


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#6 
refer to https://sap.github.io/fundamental/components/pagination.html <More than three Pages>

#### Please provide a brief summary of this pull request.
introduce private prop 'numberOfNeighbour', it defines number of neighbour to show on the left and right from the selectedPage, e.g. selectedPage=27, then 26,27,28 should be shown in the pagination with nunmberOfNeighbour = 1

#### If this is a new feature, have you updated the documentation?
