### PR TITLE
 fixes npm run serve:docs and makes npm run serve the new default

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "homepage": "https://github.com/SAP/fundamental-vue",
     "scripts": {
         "typecheck": "tsc --noEmit",
-        "serve:docs": "env VUE_APP_API_DOCS_ENABLED=true vue-cli-service serve src/docs/main.ts",
-        "serve": "vue-cli-service serve",
+        "serve:docs": "echo '\n\n⚠️⚠️⚠️ WARNING ⚠️⚠️⚠️\n\nThe serve:docs script will soon be removed.\nUse npm run serve instead.\nI will now go to sleep for 30 seconds to make you stop using this script.\n\n\n………zzzZZZZzzz………' && sleep 30 && echo 'Ok, lets go…' && npm run serve",
+        "serve": "vue-cli-service serve src/docs/main.ts",
         "build": "vue-cli-service build",
         "lint:vue": "vue-cli-service lint",
         "test": "vue-cli-service test:unit 'src/**/__tests__/*.test.{tsx,ts,js,vue}'",

--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -34,7 +34,7 @@ export class Counter extends Base<Props> {
   private get classes() {
     return {
       'fd-counter--notification': this.type === 'notification',
-    }
+    };
   }
 
   public render() {


### PR DESCRIPTION
@deepshikha02 told me that `npm run serve:docs` does not work on windows. I have no windows machine but I think that this PR fixes the issues.

Also if this is merged you will be able to do `npm run serve` and `npm run serve:docs` will yield a warning.

<img width="572" alt="screenshot 2019-01-02 at 16 33 02" src="https://user-images.githubusercontent.com/153225/50598787-1d490800-0eac-11e9-92ab-a663932672e2.png">
