### PR TITLE
fixes combobox bug

### DIFF
--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -43,7 +43,6 @@ export class Combobox extends mixins(UidMixin) {
 
   public togglePopoverVisible() {
     this.currentPopoverVisible = !this.currentPopoverVisible;
-    this.$emit('update:currentPopoverVisible', this.currentPopoverVisible);
   }
 
   private setCurrentValue(newValue: string | number | null) {
@@ -73,29 +72,38 @@ export class Combobox extends mixins(UidMixin) {
           on-click={this.handleMenuItemClick}
           noArrow={true}
           popoverVisible={this.currentPopoverVisible}
+          on-visible={(visible: boolean) => this.currentPopoverVisible = visible }
+            {...
+              {
+                scopedSlots: {
+                  control: (scope: { toggle: () => (void) }) => {
+                    return (<div staticClass='fd-combobox-control'>
+                    <InputGroup
+                      compact={this.compact}
+                      afterClass='fd-input-group__addon--button'
+                    >
+                      <Input
+                        id={this.uid}
+                        value={this.value}
+                        compact={this.compact}
+                        nativeOn-click={scope.toggle}
+                        nativeOn-keyup={this.handleKeyup}
+                        on-input={this.setCurrentValue}
+                        placeholder={this.placeholder}
+                      />
+                    <Button
+                      slot='after'
+                      on-click={scope.toggle}
+                      icon='navigation-down-arrow'
+                      styling='light'
+                    />
+                    </InputGroup></div>
+                  );
+                  },
+                },
+              }
+            }
         >
-          <div class='fd-combobox-control' slot='control'>
-            <InputGroup
-              compact={this.compact}
-              afterClass='fd-input-group__addon--button'
-            >
-              <Input
-                id={this.uid}
-                value={this.value}
-                compact={this.compact}
-                nativeOn-click={() => this.currentPopoverVisible = true}
-                nativeOn-keyup={this.handleKeyup}
-                on-input={this.setCurrentValue}
-                placeholder={this.placeholder}
-              />
-              <Button
-                slot='after'
-                on-click={this.togglePopoverVisible}
-                icon='navigation-down-arrow'
-                styling='light'
-              />
-            </InputGroup>
-          </div>
           {dropdown}
         </Popover>
       </div>

--- a/src/docs/pages/Popover/2-custom-trigger.vue
+++ b/src/docs/pages/Popover/2-custom-trigger.vue
@@ -1,14 +1,47 @@
 <title>Popover with custom Trigger</title>
+<tip>If you have special needs simply use `slot-scope`. This gives you access to the `toggle`-function and the current `visibility`. The second button is using this in order to customize the trigger event and styling.</tip>
+<docs>
+**Implementation Details**
 
-<template>
-<!-- div is needed: otherwise the popover will not be positioned correctly -->
-<div>
-  <FdPopover>
-    <FdButton styling="emphasized" type="positive" slot="control">Custom Popover Trigger Control</FdButton>
+There are three different ways a trigger control can be rendered.
+
+1. `$slots.control`: If there is a slot called `control` we simply render that. This control should emit `click`-events.
+2. `$scopedSlots.control`: If there is a scoped slot `control` we assume that the popover consumer (**you**) has some kind of special needs. Thus, when rendering the scoped slot, we pass a little bit of context to the consumer.
+
+**The context looks like this:**:
+
+```javascript
+{
+   // Calling this will toggle the popover.
+   toggle: () => (void);
+   // whether the popover is currently visible.
+   visible: boolean;
+}
+```
+
+Because of the fact that we assume that the consumer has special needs, we do not show the popover automatically. The consumer has to call `toggle` for example by binding it to `@click`/`@click.native` of some kind of control or by using `v-model`.
+
+3. If there is no (scoped) control-slot we simply render a standard button on behalf of the consumer.
+</docs>
+<template><div>
+<FdPopover>
+  <FdButton styling="emphasized" type="positive" slot="control">Custom Popover Trigger Control (automatic popover visibility)</FdButton>
     <FdMenuItem>Option 1</FdMenuItem>
     <FdMenuItem>Option 2</FdMenuItem>
     <FdMenuItem>Option 3</FdMenuItem>
-    <FdMenuItem>Option 4</FdMenuItem>
   </FdPopover>
-</div>
-</template>
+
+  <br /><br />
+
+  <FdPopover>
+    <FdButton
+      slot-scope="popover"
+      slot="control"
+      :type="popover.visible ? 'negative' : 'warning'"
+      @click="popover.toggle"
+    >Custom Popover Trigger Control (manual popover visibility)</FdButton>
+    <FdMenuItem>Option 1</FdMenuItem>
+    <FdMenuItem>Option 2</FdMenuItem>
+    <FdMenuItem>Option 3</FdMenuItem>
+  </FdPopover>
+</div></template>


### PR DESCRIPTION
2 clicks were needed to show the combobox

This also makes Popover more flexible by using scoped slots in order to let the developer customize the way the popover is triggered. Previously your trigger control had to emit click events which is not always the case (see combobox + click.native).