### PR TITLE
fix: add * to required label 

### DIFF
--- a/src/components/Form/FormLabel.tsx
+++ b/src/components/Form/FormLabel.tsx
@@ -1,6 +1,6 @@
-import { Inject } from 'vue-property-decorator';
-import { Component, DefaultSlot, Prop, Base } from '@/core';
-import { FORM_ITEM_ID_KEY } from './FormItem/Types';
+import {Inject} from 'vue-property-decorator';
+import {Component, DefaultSlot, Prop, Base} from '@/core';
+import {FORM_ITEM_ID_KEY} from './FormItem/Types';
 
 interface Props {
   for?: string | null;
@@ -8,22 +8,26 @@ interface Props {
 }
 
 @Component('FormLabel')
-@DefaultSlot('Contents of the label: For non-inline elements simply use text which will become the text displayed by the label. For inline elements use text alongside with any elements that form your input control.')
-export class FormLabel extends Base<Props> {
-  @Inject(FORM_ITEM_ID_KEY) public itemId!: string;
+@DefaultSlot('Contents of the label: For non-inline elements simply use text which will become' +
+    ' the text displayed by the label. For inline elements use text alongside with an' +
+    'y elements that form your input control.')
+export class FormLabel extends Base < Props > {
+  @Inject(FORM_ITEM_ID_KEY)public itemId !: string;
 
-  private get for(): string {
-    return this.itemId;
-  }
-
-  @Prop('whether a value is required (adds a *)', { default: false, type: Boolean })
-  public required!: boolean;
+  private get for(): string {return this.itemId;}
+  
+  @Prop('whether a value is required (adds a *)', {
+    default: false,
+    type: Boolean
+  })
+  public required !: boolean;
 
   public render() {
-    return <label staticClass='fd-form__label' class={this.classes} for={this.for}>{this.$slots.default}</label>;
-  }
-
-  private get classes() {
-    return { 'is-required': this.required };
+    return <label
+      staticClass='fd-form__label'
+      for={this.for}
+      aria-required={this.required}>{this.$slots.default}{this.required
+        ? '*'
+        : ''}</label>;
   }
 }

--- a/src/components/Form/FormLabel.tsx
+++ b/src/components/Form/FormLabel.tsx
@@ -8,9 +8,7 @@ interface Props {
 }
 
 @Component('FormLabel')
-@DefaultSlot('Contents of the label: For non-inline elements simply use text which will become' +
-    ' the text displayed by the label. For inline elements use text alongside with an' +
-    'y elements that form your input control.')
+@DefaultSlot('Contents of the label: For non-inline elements simply use text which will become the text displayed by the label. For inline elements use text alongside with any elements that form your input control.')
 export class FormLabel extends Base < Props > {
   @Inject(FORM_ITEM_ID_KEY)public itemId !: string;
 


### PR DESCRIPTION
Hello 👋 

#### Please provide a link to the associated issue.
No issue for this.

#### Please provide a brief summary of this pull request.
```is-required``` css class has been removed from labels for required fields in Forms.
Here is an example from fiori-fundamentals
![image](https://user-images.githubusercontent.com/945186/51672504-8e6b6f00-1fc3-11e9-8a52-b15c462a0d68.png)

 - added the ```aria-required``` to the label 
- added ```*``` to the label text
- removed the ```is-required``` class

#### If this is a new feature, have you updated the documentation?
no documentation change needed for this.

PS: I think prettier had a bit of fun formatting the file 😄 let me know if it's an issue and I can revert this

Cheers
Ramona 🐳