### PR TITLE
fix: Fixes CI Configuration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,6 @@
 
 ## The actual Artefacts
 !dist/FundamentalVue.*.js
+
+## Sources
+!ui/src/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - yarn global add typescript@3.3.3
 - yarn bootstrap
 script:
-  - yarn build:ui
+  - yarn build
 jobs:
   include:
   - stage: Lint and Test
@@ -41,6 +41,6 @@ notifications:
   email:
     on_failure: always
     on_success: change
-  slack: 
+  slack:
     rooms:
       - ui-fundamentals:zVRyxlqkYnQFD7p8QHkWM8Fd#vue-automated

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "serve:prod": "concurrently --kill-others --names \"dev-server,ui,docs\" -c \"blue, red,green\" \"node server\" \"yarn --cwd ui build --watch --mode production --report\" \"yarn --cwd docs serve --mode production --report\"",
     "build:ui": "yarn --cwd ui build",
     "build:docs": "yarn --cwd docs build --mode production --report",
-    "build": "rm -rf dist && yarn build:ui --mode production && yarn build:docs --mode production && mkdir dist && cp -r ui/dist/* dist && cp -r docs/dist/* dist",
+    "build:all": "rm -rf dist && yarn build:ui --mode production && yarn build:docs --mode production && mkdir dist && cp -r ui/dist/* dist && cp -r docs/dist/* dist",
+    "build": "yarn build:ui && rm -rf dist && mkdir dist && cp -r ./ui/dist/*.js dist && cp -r ./ui/dist/*.js.map dist",
     "lint": "yarn --cwd docs lint && yarn --cwd server lint && yarn --cwd ui lint",
     "release": "./scripts/publish-release.sh",
     "release:create": "create-release",
@@ -42,5 +43,6 @@
   "peerDependencies": {
     "vue": "^2.6.6"
   },
-  "main": "dist/FundamentalVue.umd.js"
+  "main": "dist/FundamentalVue.common",
+  "browser": "dist/FundamentalVue.umd.min"
 }


### PR DESCRIPTION
@jbadan, @greg-a-smith: If you check the released artefacts of `fundamental-vue@0.0.15-rc.2` you will notice that it only contains meta data information like a `package.json`-file. The actual artefacts (`FundamentalVue.umd.js`, …) are missing. There is no `dist`-folder. This is because `yarn build:ui` builds *Fundamental Vue* however the build result is located in `ui/dist` and not in `dist`. I have modified the `public-rc`-script accordingly.

I have tested it *locally* as best I could but I guess we have to merge this PR to see if it really works?
If it works I assume that the other script has to be adopted too. Right?

The project structure of Fundamental Vue is a little strange but this is how it works currently…