### PR TITLE
feat: Side Navigation Item no longer requires an id to work

### DIFF
--- a/docs/src/pages/Side Navigation/1-1-dynamic.vue
+++ b/docs/src/pages/Side Navigation/1-1-dynamic.vue
@@ -4,12 +4,12 @@
 ```typescript
 type Item = {
   // A SideNav-wide unique id
-  id: string;
+  id?: string; // default: random string
 
   // A VueRouter-Type. to can:
   // - be a string and is then interpreted as a url/path
   // - be a RouterLink compatible value for it's to-prop.
-  to?: RawLocation;
+  to?: RawLocation; // default: '#'
 
   // Displayed title
   name?: string;
@@ -18,7 +18,7 @@ type Item = {
   icon?: string;
 
   // Child items, if set this item becomes expandable.
-  children?: Item[];
+  children?: Item[]; // default: []
 }
 ```
 </docs>
@@ -34,19 +34,18 @@ export default {
   data() {
     return {
       items: [
-        { id: "1", name: "Item 1" },
-        { id: "2", name: "Item 2" },
+        { name: "Item 1" },
+        { name: "Item 2" },
         {
-          id: "3",
           name: "Item 3",
           children: [
-            { id: "3-1", name: "Item 3-1" },
-            { id: "3-2", name: "Item 3-2" },
-            { id: "3-3", name: "Item 3-3" }
+            { name: "Item 3-1" },
+            { name: "Item 3-2" },
+            { name: "Item 3-3" }
           ]
         },
-        { id: "4", name: "Item 4" },
-        { id: "5", name: "Item 5" }
+        { name: "Item 4" },
+        { name: "Item 5" }
       ]
     };
   }

--- a/docs/src/pages/Side Navigation/1-2-dynamic-static.vue
+++ b/docs/src/pages/Side Navigation/1-2-dynamic-static.vue
@@ -30,19 +30,18 @@ export default {
   data() {
     return {
       items: [
-        { id: "1", name: "Item 1" },
-        { id: "2", name: "Item 2" },
+        { name: "Item 1" },
+        { name: "Item 2" },
         {
-          id: "3",
           name: "Item 3",
           children: [
-            { id: "3-1", name: "Item 3-1" },
-            { id: "3-2", name: "Item 3-2" },
-            { id: "3-3", name: "Item 3-3" }
+            { name: "Item 3-1" },
+            { name: "Item 3-2" },
+            { name: "Item 3-3" }
           ]
         },
-        { id: "4", name: "Item 4" },
-        { id: "5", name: "Item 5" }
+        { name: "Item 4" },
+        { name: "Item 5" }
       ]
     };
   }

--- a/docs/src/pages/Side Navigation/2-data-driven-complex-sync.vue
+++ b/docs/src/pages/Side Navigation/2-data-driven-complex-sync.vue
@@ -20,35 +20,33 @@ export default {
     return {
       selectedId: "A-3",
       items: [
-        { id: "A-1", name: "Item A-1" },
+        { name: "Item A-1" },
         {
-          id: "A-2",
           name: "Item A-2",
           children: [
-            { id: "A-2-1", name: "Item A-2-1" },
-            { id: "A-2-2", name: "Item A-2-2" },
-            { id: "A-2-3", name: "Item A-2-3" }
+            { name: "Item A-2-1" },
+            { name: "Item A-2-2" },
+            { name: "Item A-2-3" }
           ]
         },
         {
           id: "A-3",
           name: "Item A-3",
           children: [
-            { id: "A-3-1", name: "Item A-3-1" },
-            { id: "A-3-2", name: "Item A-3-2" },
-            { id: "A-3-3", name: "Item A-3-3" }
+            { name: "Item A-3-1" },
+            { name: "Item A-3-2" },
+            { name: "Item A-3-3" }
           ]
         },
         {
-          id: "A-4",
           name: "Item A-4",
           children: [
-            { id: "A-4-1", name: "Item A-4-1" },
-            { id: "A-4-2", name: "Item A-4-2" },
-            { id: "A-4-3", name: "Item A-4-3" }
+            { name: "Item A-4-1" },
+            { name: "Item A-4-2" },
+            { name: "Item A-4-3" }
           ]
         },
-        { id: "A-5", name: "Item A-5" }
+        { name: "Item A-5" }
       ]
     };
   }

--- a/docs/src/pages/Side Navigation/3-data-driven-custom-render.vue
+++ b/docs/src/pages/Side Navigation/3-data-driven-custom-render.vue
@@ -27,11 +27,11 @@ export default {
     return {
       selectedId: "3",
       items: [
-        { id: "1", name: "Item 1" },
-        { id: "2", name: "Item 2" },
+        { name: "Item 1" },
+        { name: "Item 2" },
         { id: "3", name: "Item 3" },
-        { id: "4", name: "Item 4" },
-        { id: "5", name: "Item 5" }
+        { name: "Item 4" },
+        { name: "Item 5" }
       ]
     };
   }

--- a/ui/src/components/InlineHelp/__tests__/InlineHelp.test.ts
+++ b/ui/src/components/InlineHelp/__tests__/InlineHelp.test.ts
@@ -1,21 +1,21 @@
 import { shallowMount } from "@vue/test-utils";
-import InlineHelp from '../InlineHelp.vue';
+import InlineHelp from "../InlineHelp.vue";
 import { assert } from "chai";
 
 describe("InlineHelp test scripts", () => {
-    test("Renders correctly", () => {
-        const inlineHelp = shallowMount(InlineHelp, {});
-        expect(inlineHelp.element).toMatchSnapshot();
-    });
+  test("Renders correctly", () => {
+    const inlineHelp = shallowMount(InlineHelp, {});
+    expect(inlineHelp.element).toMatchSnapshot();
+  });
 
-    test("Default slot test", () => {
-        const helpText = "Slot Text";
-        const inlineHelp = shallowMount(InlineHelp, {
-            slots: {
-                default: helpText
-            }
-        });
-        expect(inlineHelp.element).toMatchSnapshot();
-        expect(inlineHelp.text()).toBe(helpText);
+  test("Default slot test", () => {
+    const helpText = "Slot Text";
+    const inlineHelp = shallowMount(InlineHelp, {
+      slots: {
+        default: helpText
+      }
     });
+    expect(inlineHelp.element).toMatchSnapshot();
+    expect(inlineHelp.text()).toBe(helpText);
+  });
 });

--- a/ui/src/components/SideNav/Model/Item.ts
+++ b/ui/src/components/SideNav/Model/Item.ts
@@ -1,7 +1,31 @@
+import { shortUuid } from "@/lib";
+
 export interface Item {
   id: string;
-  to?: string | object; // correct type: VueRouter.RawLocation;
+  to: string | object; // correct type: VueRouter.RawLocation;
+  children: Item[];
   name?: string;
   icon?: string;
-  children?: Item[];
 }
+
+export interface RawItem {
+  id?: string;
+  to?: string | object; // correct type: VueRouter.RawLocation;
+  children?: Item[];
+  name?: string;
+  icon?: string;
+}
+
+const normalizeItem = (raw: RawItem): Item => {
+  const id = raw.id || shortUuid();
+  const children = raw.children || [];
+  const to = raw.to || "#";
+  return {
+    ...raw,
+    id,
+    children,
+    to
+  };
+};
+
+export const normalizeItems = (items: RawItem[]) => items.map(normalizeItem);

--- a/ui/src/components/SideNav/Model/Store.ts
+++ b/ui/src/components/SideNav/Model/Store.ts
@@ -1,5 +1,3 @@
-import { objectValues } from "@/util";
-
 interface State {
   selectedId: string | null;
   expandedIds: string[];
@@ -12,9 +10,9 @@ const makeDefaultState = (): State => ({
   items: {}
 });
 
-type Item = { itemId: string };
-type SubItem = Item & { parentId: string };
-type Items = { [itemId: string]: Item | SubItem };
+type ParentId = string;
+type Item = null | ParentId;
+type Items = { [itemId: string]: Item };
 
 export class Store {
   constructor(readonly initialState = makeDefaultState()) {
@@ -51,19 +49,14 @@ export class Store {
     return { ...this.state.items };
   }
 
-  subItems(itemId: string): SubItem[] {
-    const items: Array<SubItem | Item> = objectValues<SubItem | Item>(
-      this.items
-    );
-    const result: SubItem[] = [];
-    items.forEach(item => {
-      if ("parentId" in item) {
-        const { parentId } = item;
-        if (parentId === itemId) {
-          result.push({ itemId: item.itemId, parentId });
-        }
+  subItems(itemId: string): Item[] {
+    const result: Item[] = [];
+    for (const currentItemId in this.items) {
+      const parentId = this.items[currentItemId];
+      if (parentId === itemId) {
+        result.push(currentItemId);
       }
-    });
+    }
     return result;
   }
 
@@ -75,7 +68,7 @@ export class Store {
   registerItem(itemId: string) {
     this.state = {
       ...this.state,
-      items: { ...this.items, [itemId]: { itemId } }
+      items: { ...this.items, [itemId]: null }
     };
   }
 
@@ -88,15 +81,15 @@ export class Store {
     };
   }
 
-  registerSubItem({ itemId, parentId }: SubItem) {
+  registerSubItem({ itemId, parentId }: { itemId: string; parentId: string }) {
     this.state = {
       ...this.state,
-      items: { ...this.items, [itemId]: { itemId, parentId } }
+      items: { ...this.items, [itemId]: parentId }
     };
   }
 
-  ununregisterSubItem({ itemId }: SubItem) {
-    this.unregisterItem(itemId);
+  ununregisterSubItem(subItemId: string) {
+    this.unregisterItem(subItemId);
   }
 
   toggleExpanded(itemId: string) {

--- a/ui/src/components/SideNav/Model/__tests__/Store.test.ts
+++ b/ui/src/components/SideNav/Model/__tests__/Store.test.ts
@@ -1,12 +1,11 @@
 import { Store } from "./../Store";
-import { assert } from "chai";
 
 describe("Store", () => {
   it("correctly handles item registration", () => {
     const store = new Store();
     const itemId = "item1";
     store.registerItem(itemId);
-    assert.deepStrictEqual(store.items, { [itemId]: { itemId } });
+    expect(store.items).toEqual({ [itemId]: null });
   });
 
   it("correctly handles item unregistration", () => {
@@ -14,11 +13,11 @@ describe("Store", () => {
     const store = new Store({
       selectedId: null,
       expandedIds: [],
-      items: { [itemId]: { itemId } }
+      items: { [itemId]: null }
     });
-    assert.deepStrictEqual(store.items, { [itemId]: { itemId } });
+    expect(store.items).toEqual({ [itemId]: null });
     store.unregisterItem(itemId);
-    assert.deepStrictEqual(store.items, {});
+    expect(store.items).toEqual({});
   });
 
   it("correctly handles subitem registration", () => {
@@ -30,9 +29,9 @@ describe("Store", () => {
     const subItemId = "subItem1";
     store.registerSubItem({ itemId: subItemId, parentId: itemId });
 
-    assert.deepStrictEqual(store.items, {
-      [itemId]: { itemId },
-      [subItemId]: { itemId: subItemId, parentId: itemId }
+    expect(store.items).toEqual({
+      [itemId]: null,
+      [subItemId]: itemId
     });
   });
 
@@ -59,16 +58,16 @@ describe("Store", () => {
     const subItemId23 = "item_2__sub_3";
     store.registerSubItem({ itemId: subItemId23, parentId: itemId2 });
 
-    assert.sameDeepMembers(store.subItems(itemId1), [
-      { itemId: subItemId11, parentId: itemId1 },
-      { itemId: subItemId12, parentId: itemId1 },
-      { itemId: subItemId13, parentId: itemId1 }
+    expect(store.subItems(itemId1)).toEqual([
+      subItemId11,
+      subItemId12,
+      subItemId13
     ]);
 
-    assert.sameDeepMembers(store.subItems(itemId2), [
-      { itemId: subItemId21, parentId: itemId2 },
-      { itemId: subItemId22, parentId: itemId2 },
-      { itemId: subItemId23, parentId: itemId2 }
+    expect(store.subItems(itemId2)).toEqual([
+      subItemId21,
+      subItemId22,
+      subItemId23
     ]);
   });
 });

--- a/ui/src/components/SideNav/SideNav.vue
+++ b/ui/src/components/SideNav/SideNav.vue
@@ -5,8 +5,7 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { PropValidator } from "vue/types/options";
+import Vue, { PropOptions } from "vue";
 import { Config, Store, Modes, Mode, ModeType } from "./Model";
 
 export default Vue.extend({
@@ -18,11 +17,11 @@ export default Vue.extend({
     };
   },
   props: {
-    selectedId: { type: String, default: null } as PropValidator<string | null>,
+    selectedId: { type: String, default: null } as PropOptions<string | null>,
     mode: {
       default: Mode.manual,
       validator: (value: any) => Modes.indexOf(value) >= 0
-    } as PropValidator<ModeType>
+    } as PropOptions<ModeType>
   },
   computed: {
     store(): Store {

--- a/ui/src/components/SideNav/SideNavGroup.vue
+++ b/ui/src/components/SideNav/SideNavGroup.vue
@@ -1,10 +1,9 @@
 <template>
-  <div class="d-side-nav__group"><slot /></div>
+  <div class="fd-side-nav__group"><slot /></div>
 </template>
 
-<script lang="ts">
-import Vue from "vue";
-export default Vue.extend({
+<script>
+export default {
   name: "FdSideNavGroup"
-});
+};
 </script>

--- a/ui/src/components/SideNav/SideNavItem.vue
+++ b/ui/src/components/SideNav/SideNavItem.vue
@@ -15,9 +15,7 @@ export default mixins(Uid).extend({
       sideNavItem: this
     };
   },
-  inject: {
-    sideNavStore: { from: "sideNavStore" }
-  },
+  inject: ["sideNavStore"],
   mounted(): void {
     this.store.registerItem(this.itemId);
   },

--- a/ui/src/components/SideNav/SideNavList.vue
+++ b/ui/src/components/SideNav/SideNavList.vue
@@ -1,21 +1,23 @@
 <script lang="ts">
-import Vue, { CreateElement, VNode } from "vue";
-import { Item, Store } from "./Model";
+import Vue, { CreateElement, VNode, PropOptions } from "vue";
+import { Item, RawItem, Store, normalizeItems } from "./Model";
 import SideNavSubItem from "./SideNavSubItem.vue";
 import SideNavSubLink from "./SideNavSubLink.vue";
 import SideNavLink from "./SideNavLink.vue";
 import SideNavItem from "./SideNavItem.vue";
 import SideNavIcon from "./SideNavIcon.vue";
 import SideNavSubList from "./SideNavSubList.vue";
-import { PropValidator } from "vue/types/options";
 
 export default Vue.extend({
   name: "FdSideNavList",
   inject: ["sideNavStore"],
   props: {
-    items: { type: Array, default: () => [] } as PropValidator<Item[]>
+    items: { type: Array, default: () => [] } as PropOptions<RawItem[]>
   },
   computed: {
+    normalizedItems(): Item[] {
+      return normalizeItems(this.items);
+    },
     store(): Store {
       // @ts-ignore
       return this.sideNavStore;
@@ -75,6 +77,7 @@ export default Vue.extend({
       return h(
         SideNavItem,
         {
+          key: id,
           props: { uid: id }
         },
         [
@@ -88,7 +91,7 @@ export default Vue.extend({
 
     return h("ul", { class: "fd-side-nav__list" }, [
       ...(this.$slots.default || []),
-      ...this.items.map(renderItem)
+      ...this.normalizedItems.map(renderItem)
     ]);
   }
 });

--- a/ui/src/mixins/withTargetLocation.ts
+++ b/ui/src/mixins/withTargetLocation.ts
@@ -34,7 +34,11 @@ export default (defaultTo: string | object | null = null) =>
           return;
         }
         $router.push(to, onComplete);
-        this.$emit("click", event);
+        if (event != null) {
+          this.$emit("click", event);
+        } else {
+          this.$emit("click");
+        }
       }
     }
   });


### PR DESCRIPTION
I am breaking #178 up in multiple PRs to make things not so big.

This PR simply makes the id of side nav items options and cleans up parts of the code.

With this PR I am also starting a small SideNav overhaul. I would like to remove redundant code and add tests. This is a prerequisite for the overhaul.