### PR TITLE
fix: Add stop event modifier on modal example page to avoid event propagation

### DIFF
--- a/docs/src/pages/Modal/Example.vue
+++ b/docs/src/pages/Modal/Example.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div>
-    <FdButton @click="showModal">Show Modal</FdButton>
+    <FdButton @click.stop="showModal">Show Modal</FdButton>
     <FdModal title="Modal Title" :active.sync="isModalActive">
       <p>Do you want to invite your friends to join the party?</p>
       <template slot="actions">


### PR DESCRIPTION
#### Associated Issue
Fixes #252

#### Summary
This adds the `stop` event modifier to the modal's example page "Show Modal" button in order to prevent that the button is immediately close again.