### PR TITLE
chore: Release notes

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -16,9 +16,10 @@ echo "$std_ver"
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
-yarn release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
-
 npm publish
+
+# run this after publish to make sure GitHub finishes updating from the push
+yarn release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
 
 # deploy documentation site to github pages branch
 yarn deploy:docs


### PR DESCRIPTION
#### Please provide a link to the associated issue.
n/a

#### Please provide a brief summary of this pull request.
It was found in the `fundamental` repo that the calls to GitHub API to build the release notes _could_ happen prior to the commits being pushed (or updated within GitHub).  To help ensure this works, I have moved the create release call below publish.

#### If this is a new feature, have you updated the documentation?
n/a