### PR TITLE
test: Tests will now fail if Vue logs warning/error via console.error.

### DIFF
--- a/ui/jest.setup.js
+++ b/ui/jest.setup.js
@@ -16,3 +16,20 @@ if (typeof process.env.FD_LISTENING_TO_UNHANDLED_REJECTION === "undefined") {
   // Avoid memory leak by adding too many listeners
   process.env.FD_LISTENING_TO_UNHANDLED_REJECTION = "YES";
 }
+
+const VUE_WARN_TOKEN = "[Vue warn]";
+const VUE_ERROR_TOKEN = "[Vue error]";
+
+// eslint-disable-next-line no-console
+const _console__error = console.error;
+
+// eslint-disable-next-line no-console
+console.error = (msg, ...params) => {
+  _console__error(msg, params);
+
+  if (msg.indexOf(VUE_WARN_TOKEN) > -1 || msg.indexOf(VUE_ERROR_TOKEN) > -1) {
+    throw Error(
+      "Detected a warning/error from Vue. This will fail the test that caused it. The causing error was logged above."
+    );
+  }
+};

--- a/ui/src/components/Layout/ShellBar/ShellBarProduct.vue
+++ b/ui/src/components/Layout/ShellBar/ShellBarProduct.vue
@@ -8,8 +8,11 @@
 </template>
 
 <script>
+import FdShellBarProductTitle from "./ShellBarProductTitle.vue";
+
 export default {
   name: "FdShellBarProduct",
+  components: { FdShellBarProductTitle },
   props: { productTitle: { type: String, default: null } }
 };
 </script>


### PR DESCRIPTION
This PR makes our tests better. There are situations in which Vue will warn/log an error but not throw an exception. For example if a component is used which was not registered. In the past tests did not fail in those cases. This PR changes that.