### PR TITLE
fix: docs site deploy, add missing build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "test": "yarn --cwd ui test",
     "test:watch": "yarn --cwd ui test:watch",
-    "deploy:docs": "yarn build:docs && cp ui/dist/*.js docs/dist && gh-pages -d docs/dist"
+    "deploy:docs": "yarn bootstrap && yarn build:ui --mode production && yarn build:docs && cp ui/dist/*.js docs/dist && gh-pages -d docs/dist"
   },
   "description": "SAP Fiori Fundamentals, implemented in Vue.js",
   "keywords": [


### PR DESCRIPTION
#### Please provide a link to the associated issue.

`yarn deploy:docs` was missing some key steps - `yarn bootstrap` and `yarn build:ui`

The docs site should be working now. If you're seeing errors, try clearing the cache and hard reloading.

#### Please provide a brief summary of this pull request.

#### If this is a new feature, have you updated the documentation?
