### PR TITLE
modal dimensions can now be controlled and set to fullscreen if needed

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -5,7 +5,7 @@
         <div
           :key="name"
           ref="modalEl"
-          class="fd-modal"
+          class="fd-modal fd-modal--overrides"
           v-show="visible"
           :data-fd-modal-identifier="name"
           :aria-hidden="String(!visible)"
@@ -14,13 +14,11 @@
           @keydown.esc="handleEsc"
           v-bind="$attrs"
         >
-          <div class="fd-modal__content" role="document">
+          <div class="fd-modal__content fd-modal__content--overrides" role="document">
             <div class="fd-modal__header">
               <!-- Custom Title Content -->
               <slot name="title" v-bind="this">
-                <h3 class="fd-modal__title">
-                  {{ title }}
-                </h3>
+                <h3 class="fd-modal__title">{{ title }}</h3>
               </slot>
               <slot name="close" v-bind="this">
                 <FdButton
@@ -34,7 +32,7 @@
 
             <!-- BODY -->
 
-            <div class="fd-modal__body">
+            <div class="fd-modal__body fd-modal__body--overrides">
               <slot v-bind="this" />
             </div>
 
@@ -72,7 +70,11 @@ export default {
       type: Boolean,
       default: false
     },
-    modalStyle: { default: null },
+    modalStyle: {
+      default: () => ({
+        "max-width": "460px"
+      })
+    },
     title: { type: String, default: null },
     name: {
       type: String,

--- a/src/components/Modal/modal.scss
+++ b/src/components/Modal/modal.scss
@@ -3,6 +3,7 @@
 .fdv-overlay-leave-active {
   transition: opacity 0.15s;
 }
+
 .fdv-overlay-enter,
 .fdv-overlay-leave-to {
   opacity: 0;
@@ -13,17 +14,42 @@
   opacity: 0;
   transform: scale3d(1, 1, 1) translate3d(0, -400px, 0);
 }
+
 .fdv-modal-enter-to {
   transform: scale3d(1, 1, 1);
 }
+
 .fdv-modal-enter-active,
 .fdv-modal-leave-active {
   transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
+
 .fdv-modal-leave {
   transform: scale3d(1, 1, 1);
 }
+
 .fdv-modal-leave-to {
   opacity: 0;
   transform: scale3d(1, 1, 1) translate3d(0, -400px, 0);
+}
+
+.fd-modal__content--overrides {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  min-width: inherit;
+  max-width: inherit;
+  min-height: inherit;
+  max-height: inherit;
+  flex-direction: column;
+}
+
+.fd-modal--overrides {
+  max-width: none;
+}
+
+.fd-modal__body--overrides {
+  flex-grow: 1;
+  display: block;
+  overflow: auto;
 }

--- a/src/docs/content/en_us/modal.md
+++ b/src/docs/content/en_us/modal.md
@@ -29,6 +29,11 @@ Of course you can also manually show or close the modal by simply calling the co
 <d-example name="default-modal">
 </d-example>
 
+## Fullscreen Modal
+The modal dimensions can be controlled through the width and height properties of the configuration object. These accept strings, so you may use whatever unit works best for your situation.
+<d-example name="fullscreen-modal">
+</d-example>
+
 ## Nested Modals
 
 You can nest modals just by calling `$fdModal.open(…)` multiple times.

--- a/src/docs/content/examples/modal/fullscreen-modal.vue
+++ b/src/docs/content/examples/modal/fullscreen-modal.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <fd-modal
+      name="crew"
+      ref="crew"
+      :modal-style="{ width: '100vw', height: '100vh' }"
+      title="Nakama"
+    >
+      <template #default="{close}">
+        <div>
+          <p>Do you want to join my crew Jinbei?</p>
+          <p>
+            <fd-link @click="close">I can't do that now</fd-link>
+            – I need to take care of something first.
+          </p>
+        </div>
+      </template>
+      <template #actions="{close}">
+        <fd-button @click="close" styling="light">Cancel</fd-button>
+        <fd-button @click="close" styling="emphasized">Join</fd-button>
+      </template>
+    </fd-modal>
+    <fd-button v-fd-open-modal:crew>Show Modal</fd-button>
+    <br />
+    <br />
+    <fd-button @click="$fdModal.open('crew')">
+      Show Modal using $fdModal.open(…)
+    </fd-button>
+  </div>
+</template>


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.
Some properties of the default modal styles were overridden to allow the dev to customize the size of the modal

#### If this is a new feature, have you updated the documentation?
Yes, a new example was added