### PR TITLE
bodyStyles is now a prop for Popover + updated documentation

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -6,6 +6,7 @@
     :defaultBodyZIndex="defaultBodyZIndex"
     :portal-id="$fdDefaultPortalId"
     :body-class="fdBodyClass"
+    :body-styles="popoverBodyStyles"
     :placement="placement"
     :with-arrow="withArrow"
     :body-size-mode="bodySizeMode"
@@ -60,6 +61,14 @@ export default {
       return [...this.ignoredElements(), this.controlEl];
     }
   },
+  data() {
+    return {
+      defaultBodyStyles: {
+        maxHeight: "300px",
+        overflowY: "auto"
+      }
+    };
+  },
   computed: {
     kpop() {
       return this.$refs.kpop;
@@ -77,14 +86,15 @@ export default {
         result.push("fd-popover__popper--no-arrow");
       }
       return result.join(" ");
+    },
+    popoverBodyStyles() {
+      return { ...this.defaultBodyStyles, ...this.bodyStyles };
     }
   },
   props: {
-    // Default z-index that should be used for the popover body.
-    defaultBodyZIndex: {
-      type: Number,
-      // `1000`
-      default: 1000
+    adjustsBodyWidth: {
+      type: Boolean,
+      default: false
     },
     // Use a custom body size mode. For details please refer to the [K-Pop](https://christiankienle.github.io/k-pop/examples/#body-size-modes) documentation.
     bodySizeMode: {
@@ -94,9 +104,16 @@ export default {
       // `auto`
       default: BodySizeMode.defaultMode
     },
-    adjustsBodyWidth: {
-      type: Boolean,
-      default: false
+    // Custom styles object
+    bodyStyles: {
+      type: Object,
+      default: () => {}
+    },
+    // Default z-index that should be used for the popover body.
+    defaultBodyZIndex: {
+      type: Number,
+      // `1000`
+      default: 1000
     },
     // Customize elements that can be interacted with, without the popover being dismissed.
     ignoredElements: {

--- a/src/docs/content/en_us/popover.md
+++ b/src/docs/content/en_us/popover.md
@@ -30,6 +30,29 @@ You can use those slot-props to customize all sorts of things. For example, show
 <d-example name="default-popover">
 </d-example>
 
+## Scrolling and Styling
+
+You can pass a styles object to the `body-styles` prop which will allow you to customize the popover's body. The styles object that is provided by default is the following:
+
+```js
+defaultBodyStyles: {
+  maxHeight: "300px",
+  overflowY: "auto"
+}
+```
+You can override these properties and add your custom styling.
+
+::: tip
+
+Try to avoid manipulating css properties that might interfere with those controlled by other props (e.g: width). 
+
+:::
+
+In the example below you can use the slider to control the `max-height` property of the popover's body.
+
+<d-example name="default-styles">
+</d-example>
+
 ## Placement Options
 
 Use the `placement`-prop to any of the following values: `bottom-start`, `bottom`, `bottom-end`, `left-start`, `left`, `left-end`, `right-start`, `right`, `right-end`, `top-start`, `top` and `top-end`.

--- a/src/docs/content/examples/popover/default-styles.vue
+++ b/src/docs/content/examples/popover/default-styles.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <div class="sliders">
+      <p>Max height: {{ maxHeight }}px</p>
+      <input v-model.number="maxHeight" type="range" min="1" max="600" />
+    </div>
+    <fd-popover :body-styles="{ maxHeight: `${maxHeight}px` }" boundary="viewport">
+      <template #control="{toggle}">
+        <fd-button @click="toggle">Long options list</fd-button>
+      </template>
+      <template #default="{hide}">
+        <fd-menu @select="hide">
+          <fd-menu-list>
+            <fd-menu-item v-for="i in items" :key="i">Option {{ i }}</fd-menu-item>
+          </fd-menu-list>
+        </fd-menu>
+      </template>
+    </fd-popover>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    items() {
+      return this.generateData();
+    }
+  },
+  methods: {
+    generateData() {
+      const items = [];
+      for (let i = 0; i < 100; i++) {
+        items.push(i);
+      }
+      return items;
+    }
+  },
+  data() {
+    return {
+      maxHeight: 250
+    };
+  }
+};
+</script>
+
+<style>
+.sliders,
+.sliders input {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.
The  popover was already forwarding a bodyStyles attribute to its internal implementation but was not explicitly mentioned. So, it was made into a prop  and sensible defaults were provided.
#### If this is a new feature, have you updated the documentation?
Yes new example was added.