### PR TITLE
fix: uicomp-1102 change standard-version commit message format

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "deploy:docs": "yarn build:docs:ghpages && gh-pages -d docs/dist",
     "release": "./scripts/publish-release.sh",
     "release:create": "create-release",
-    "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\""
+    "std-version": "standard-version --releaseCommitMessageFormat \"chore(release): version {{currentTag}} build ${TRAVIS_BUILD_NUMBER} [ci skip]\""
   },
   "main": "dist/FundamentalVue.cjs.js",
   "module": "dist/FundamentalVue.esm.js",


### PR DESCRIPTION
## Jira ID [UICOMP-1102](https://jira.concur.com/jira/browse/UICOMP-1102)

### Description
`-m` or `--message` is deprecated https://github.com/conventional-changelog/standard-version/blob/master/command.js#L33

Instead of using `%s` we can use `{{currentTag}}` -- https://github.com/conventional-changelog/standard-version/blob/ae032bfa9268a0a14351b0d78b6deedee7891e3a/test.js#L1244
