### PR TITLE
fix:  Display label instead of value on combobox when label is present

### DIFF
--- a/src/components/combobox/__tests__/combobox.test.js
+++ b/src/components/combobox/__tests__/combobox.test.js
@@ -48,4 +48,39 @@ describe('Combobox', () => {
     expect(item.text()).toBe('1') // ensure that we have selected the correct item
     expect(wrapper.vm.value).toBe('1')
   })
+
+  it('Combobox items with labels', async () => {
+    const wrapper = mount({
+      components: { FdCombobox, FdMenuItem, FdMenuLink },
+      template: `
+      <FdCombobox ref="combobox" v-model="value">
+        <FdMenuItem ref="menuItem1" value="1" label="A">
+          <FdMenuLink>1</FdMenuLink>
+        </FdMenuItem>
+        <FdMenuItem value="2" label="B">
+          <FdMenuLink>2</FdMenuLink>
+        </FdMenuItem>
+        <FdMenuItem value="3" label="C">
+          <FdMenuLink>3</FdMenuLink>
+        </FdMenuItem>
+        <FdMenuItem value="4" label="D">
+          <FdMenuLink>4</FdMenuLink>
+        </FdMenuItem>
+      </FdCombobox>
+      `,
+      data() {
+        return {
+          value: 'abc'
+        }
+      }
+    })
+    await wrapper.vm.$nextTick()
+    const item = wrapper.find({ ref: 'menuItem1' })
+    item.find('a').trigger('click')
+    expect(item.text()).toBe('1') // ensure that we have selected the correct item
+    expect(wrapper.vm.value).toBe('1')
+
+    const combobox = wrapper.find({ ref: 'combobox' })
+    expect(combobox.vm.displayValue).toBe('A') // ensure that the value being displayed is the label
+  })
 })

--- a/src/components/combobox/combobox.vue
+++ b/src/components/combobox/combobox.vue
@@ -159,7 +159,7 @@ export default {
       this.currentLabel = newLabel
     },
     handleUpdate(newValue) {
-      this.setCurrentValue(newValue);
+      this.setCurrentValue(newValue)
       this.setCurrentLabel(null) // reset the current label as a new value is being set
     }
   }

--- a/src/components/combobox/combobox.vue
+++ b/src/components/combobox/combobox.vue
@@ -3,7 +3,7 @@
     <template #input="{showCompletions, hideCompletions}">
       <FdInputGroupInput
         ref="input"
-        :value="currentValue"
+        :value="displayValue"
         :placeholder="placeholder"
         :compact="compact"
         @blur="handleBlur"
@@ -86,12 +86,17 @@ export default {
   computed: {
     comboboxBase() {
       return this.$refs.comboboxBase
+    },
+    displayValue() {
+      return this.currentLabel ?? this.currentValue
     }
   },
   data() {
     return {
       // type: string | number | null
-      currentValue: this.value
+      currentValue: this.value,
+      // type: string | number | null
+      currentLabel: null
     }
   },
   watch: {
@@ -135,6 +140,7 @@ export default {
     },
     selectItem(item) {
       this.setCurrentValue(item.value)
+      this.setCurrentLabel(item.label)
       this.$refs.comboboxBase.hide()
     },
     ignoredElements() {
@@ -148,6 +154,9 @@ export default {
       // Trigged when the current value changes
       // @arg the current value
       this.$emit('update:value', this.currentValue)
+    },
+    setCurrentLabel(newLabel) {
+      this.currentLabel = newLabel
     }
   }
 }

--- a/src/components/combobox/combobox.vue
+++ b/src/components/combobox/combobox.vue
@@ -8,7 +8,7 @@
         :compact="compact"
         @blur="handleBlur"
         @focus="showCompletions"
-        @update="setCurrentValue"
+        @update="handleUpdate"
         @keyup.esc="hideCompletions"
       />
     </template>
@@ -157,6 +157,10 @@ export default {
     },
     setCurrentLabel(newLabel) {
       this.currentLabel = newLabel
+    },
+    handleUpdate(newValue) {
+      this.setCurrentValue(newValue);
+      this.setCurrentLabel(null) // reset the current label as a new value is being set
     }
   }
 }

--- a/src/components/menu/menu-item.vue
+++ b/src/components/menu/menu-item.vue
@@ -44,7 +44,8 @@ export default {
   },
   props: {
     selected: { type: Boolean, default: false },
-    value: { default: null, type: [String, Number] }
+    value: { default: null, type: [String, Number] },
+    label: { default: null, type: [String, Number] }
   },
   computed: {
     canHaveAddon() {

--- a/src/docs/pages/combobox/combobox.md
+++ b/src/docs/pages/combobox/combobox.md
@@ -22,6 +22,17 @@ All `fd-menu-item`s need an associated `value` – otherwise `v-model` will not 
 <d-example name="sizes">
 </d-example>
 
+## Combobox Labels
+
+::: tip
+
+You can optionally supply a `label` value to `fd-menu-item` and it will be displayed instead of `value`. 
+But it will keep the `v-model` value as the `value` field.
+
+:::
+<d-example name="labels">
+</d-example>
+
 ## Custom Menu
 
 ::: tip

--- a/src/docs/pages/combobox/labels.vue
+++ b/src/docs/pages/combobox/labels.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <p>
+      <strong>Selected number:</strong>
+    </p>
+    <p>{{ number || 'none' }}</p>
+    <fd-combobox v-model="number" placeholder="Pick your favorite Number">
+      <template #default>
+        <FdMenuItem value="1" label="One">One</FdMenuItem>
+        <FdMenuItem value="2" label="Two">Two</FdMenuItem>
+        <FdMenuItem value="3" label="Three">Three</FdMenuItem>
+      </template>
+    </fd-combobox>
+  </div>
+</template>
+
+<script>
+export default {
+  data: () => ({ number: null })
+}
+</script>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Should address #302 

#### Please provide a brief summary of this pull request.
This PR adds the functionality of displaying the _label_ field instead of the _value_ field on Comboboxes

#### If this is a new feature, have you updated the documentation?
I have added a example to the docs